### PR TITLE
Fix mobile layout for GetYourGuide widget

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -96,6 +96,18 @@
       overflow: hidden;
       width: 100%;
     }
+    [data-gyg-widget="activities"] {
+      width: 100%;
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      overflow-x: auto;
+    }
+    [data-gyg-widget="activities"] iframe {
+      flex: 1 1 300px;
+      display: block;
+      width: 100%;
+    }
     .history-section {
       background: linear-gradient(to bottom, #ffffff 0%, #f0f0f0 100%);
       width: 100%;
@@ -164,5 +176,9 @@
       }
       .activities-widget .gyg-frame {
         height: 1100px;
+      }
+      [data-gyg-widget="activities"] {
+        overflow-x: auto;
+        flex-wrap: wrap;
       }
     }

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
 </div>
   <h3 style="margin-top: 40px;">🛥️ Top-Rated Seine River Boat Tours</h3>
   <p>Explore additional Parisian river experiences, including <strong>sightseeing cruises</strong>, <strong>dinner boat tours</strong>, and romantic evening rides on the Seine.</p>
-  <div class="container">
+  <div class="container" data-gyg-widget="activities">
   <iframe
     src="https://widget.getyourguide.com/default/activities.frame?q=seine&partner_id=X3LLOUG&locale_code=en-US&number_of_items=8"
     loading="lazy"


### PR DESCRIPTION
## Summary
- tweak GetYourGuide activities section markup so it can be targeted
- add responsive CSS rules for `[data-gyg-widget="activities"]` to allow scrolling/wrapping on small screens

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68604622a5c48322b37849db742f8497