### PR TITLE
Fix GetYourGuide widget height on mobile

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -79,7 +79,8 @@
     }
     .gyg-frame {
       width: 100%;
-      height: 1000px;
+      height: auto;
+      min-height: 1000px;
       border: none;
       border-radius: 12px;
       box-shadow: 0 4px 12px rgba(0,0,0,0.1);
@@ -93,8 +94,9 @@
       background: linear-gradient(to bottom, #cceeff 0%, #f0f8ff 100%);
       padding: 40px 20px;
       text-align: center;
-      overflow: hidden;
       width: 100%;
+      overflow: visible;
+      min-height: auto;
     }
     [data-gyg-widget="activities"] {
       width: 100%;
@@ -102,6 +104,8 @@
       flex-wrap: wrap;
       justify-content: center;
       overflow-x: auto;
+      overflow-y: visible;
+      min-height: auto;
     }
     [data-gyg-widget="activities"] iframe {
       flex: 1 1 300px;
@@ -175,10 +179,20 @@
         height: 360px;
       }
       .activities-widget .gyg-frame {
-        height: 1100px;
+        height: auto !important;
+        min-height: auto !important;
       }
       [data-gyg-widget="activities"] {
         overflow-x: auto;
         flex-wrap: wrap;
+        height: auto !important;
+        min-height: auto !important;
+        overflow: visible !important;
+        display: block !important;
+      }
+      .activities-widget {
+        height: auto !important;
+        min-height: auto !important;
+        overflow: visible !important;
       }
     }


### PR DESCRIPTION
## Summary
- allow embedded widget containers to grow with content
- ensure the activities widget expands fully on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860486cf5fc8322a42315f5f35e638d