### PR TITLE
Fix mobile activities widget height

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -90,6 +90,9 @@
     .gyg-featured {
       height: 400px;
     }
+    .gyg-activities {
+      min-height: 1600px;
+    }
     .activities-widget {
       background: linear-gradient(to bottom, #cceeff 0%, #f0f8ff 100%);
       padding: 40px 20px;
@@ -186,5 +189,8 @@
         flex-wrap: wrap;
         overflow: visible !important;
         display: block !important;
+      }
+      .gyg-activities {
+        min-height: 2200px;
       }
     }

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
     loading="lazy"
     title="More Seine Activities"
     scrolling="no"
-    class="gyg-frame">
+    class="gyg-frame gyg-activities">
   </iframe>
 </div>
 </section>


### PR DESCRIPTION
## Summary
- add custom gyg-activities class for widget iframe
- adjust CSS to give the activities widget extra height on mobile

## Testing
- `npx --yes htmlhint index.html`
- `npx --yes htmlhint pages/hotels.html`
- `npx --yes stylelint "**/*.css"` *(fails: No configuration provided)*

------
https://chatgpt.com/codex/tasks/task_e_68604bde3ba48322bf863a3aa23f9c35