### PR TITLE
Adjust mobile widget height

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -91,7 +91,7 @@
       height: 400px;
     }
     .gyg-activities {
-      min-height: 1600px;
+      min-height: 2000px;
     }
     .activities-widget {
       background: linear-gradient(to bottom, #cceeff 0%, #f0f8ff 100%);
@@ -191,6 +191,6 @@
         display: block !important;
       }
       .gyg-activities {
-        min-height: 2200px;
+        min-height: 3000px;
       }
     }


### PR DESCRIPTION
## Summary
- fix `gyg-activities` iframe height for desktop and mobile

## Testing
- `grep -n min-height assets/css/style.css`

------
https://chatgpt.com/codex/tasks/task_e_686312a1fbd88322bad1a5358209c1de