### PR TITLE
Fix desktop spacing for activities widget

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -91,7 +91,8 @@
       height: 400px;
     }
     .gyg-activities {
-      min-height: 2000px;
+      /* allow dynamic resizing to avoid large gaps on desktop */
+      min-height: 0;
     }
     .activities-widget {
       background: linear-gradient(to bottom, #cceeff 0%, #f0f8ff 100%);


### PR DESCRIPTION
## Summary
- let the activities widget height adjust automatically on desktop

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686315d61a54832284df47dc5335e586