### PR TITLE
Fix desktop widget height

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -91,8 +91,8 @@
       height: 400px;
     }
     .gyg-activities {
-      /* allow dynamic resizing to avoid large gaps on desktop */
-      min-height: 0;
+      /* ensure enough space for all desktop activities */
+      min-height: 2000px;
     }
     .activities-widget {
       background: linear-gradient(to bottom, #cceeff 0%, #f0f8ff 100%);


### PR DESCRIPTION
## Summary
- ensure the GetYourGuide activities widget always shows 8 results on desktop

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863178e2c64832287b7aed4eac456c6