### PR TITLE
Fix whitespace on desktop widget

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -91,8 +91,8 @@
       height: 400px;
     }
     .gyg-activities {
-      /* ensure enough space for all desktop activities */
-      min-height: 2000px;
+      /* reduce whitespace while showing all desktop activities */
+      min-height: 1500px;
     }
     .activities-widget {
       background: linear-gradient(to bottom, #cceeff 0%, #f0f8ff 100%);


### PR DESCRIPTION
## Summary
- decrease minimum height for desktop activities widget to avoid excess spacing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68631931f3b483228a0ae61af64d2218