### PR TITLE
Fix mobile layout for GetYourGuide widget

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -87,9 +87,12 @@
       display: block;
       margin: 0 auto;
     }
-    .gyg-featured {
-      height: 400px;
-    }
+  .gyg-featured {
+    height: 400px;
+  }
+  .gyg-horizontal-wrapper {
+    overflow-x: auto;
+  }
     .gyg-activities {
       /* reduce whitespace while showing all desktop activities */
       min-height: 1000px;
@@ -184,6 +187,12 @@
       }
       .activities-widget .gyg-frame {
         width: 100%;
+      }
+      .gyg-horizontal-wrapper {
+        -webkit-overflow-scrolling: touch;
+      }
+      .gyg-horizontal-wrapper .gyg-frame {
+        min-width: 600px;
       }
       [data-gyg-widget="activities"] {
         overflow-x: auto;

--- a/index.html
+++ b/index.html
@@ -30,8 +30,8 @@
   <h2>Seine River Cruises</h2>
   <p>🚢 Below you'll find our <strong>featured cruise</strong> — a curated experience that stands out for its reviews, views and value. This cruise may also appear in the broader list of activities below.</p>
   </div>
-  <div class="container">
-  <iframe 
+  <div class="container gyg-horizontal-wrapper">
+  <iframe
     src="https://widget.getyourguide.com/default/availability.frame?tour_id=409183&partner_id=X3LLOUG&locale_code=en-US&currency=EUR&widget=availability&variant=horizontal"
     title="Featured Seine Cruise"
     scrolling="no"


### PR DESCRIPTION
## Summary
- wrap GetYourGuide widget in a new `gyg-horizontal-wrapper`
- allow horizontal scrolling and set minimum width for mobile

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68631c1dbc948322a4d69f910a7bd621