### PR TITLE
Fix whitespace under GetYourGuide widget

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -80,7 +80,6 @@
     .gyg-frame {
       width: 100%;
       height: auto;
-      min-height: 1000px;
       border: none;
       border-radius: 12px;
       box-shadow: 0 4px 12px rgba(0,0,0,0.1);


### PR DESCRIPTION
## Summary
- avoid forcing large `min-height` on GetYourGuide iframes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686327c69ccc832294c2c3af3316185b