### PR TITLE
Fix widget height on mobile

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -221,6 +221,7 @@
         display: block !important;
       }
       .gyg-activities {
-        min-height: 3000px;
+        /* allow height to fit content on mobile to avoid large gaps */
+        min-height: 0;
       }
     }


### PR DESCRIPTION
## Summary
- fix GYG activities widget height for mobile devices

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6863298f51dc8322b33c637f21b0011a