### PR TITLE
Fix mobile height for GetYourGuide widget

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -105,8 +105,8 @@
     display: none;
   }
     .gyg-activities {
-      /* reduce whitespace while showing all desktop activities */
-      min-height: 1000px;
+      /* ensure entire list of activities is visible */
+      min-height: 1500px;
     }
     .activities-widget {
       background: linear-gradient(to bottom, #cceeff 0%, #f0f8ff 100%);
@@ -221,7 +221,7 @@
         display: block !important;
       }
       .gyg-activities {
-        /* allow height to fit content on mobile to avoid large gaps */
-        min-height: 0;
+        /* ensure mobile widget displays all 8 activities without extra gap */
+        height: 2000px;
       }
     }


### PR DESCRIPTION
## Summary
- adjust default `min-height` for the activities iframe
- specify a taller fixed height on mobile so all activities display

## Testing
- `htmlhint index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68632b2fd40c83229ee8e85ab81663f5