### PR TITLE
Fix GetYourGuide widget height on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,5 +126,6 @@
   </footer>
     </main>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.11.3/js/lightbox-plus-jquery.min.js"></script>
+  <script async src="https://widget.getyourguide.com/dist/js/getyourguide-iframeapi.min.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- load GetYourGuide's iframe API script to allow its widgets to size properly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68632e9ec728832295aa9c7e0816e280