### PR TITLE
Fix mobile widget height

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -107,6 +107,7 @@
     .gyg-activities {
       /* allow the widget to define its own height */
       height: auto;
+      min-height: 600px;
     }
     .activities-widget {
       background: linear-gradient(to bottom, #cceeff 0%, #f0f8ff 100%);
@@ -223,5 +224,6 @@
       .gyg-activities {
         /* allow the widget to size itself on mobile */
         height: auto;
+        min-height: 1600px;
       }
     }

--- a/index.html
+++ b/index.html
@@ -126,6 +126,6 @@
   </footer>
     </main>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.11.3/js/lightbox-plus-jquery.min.js"></script>
-  <script async src="https://widget.getyourguide.com/dist/js/getyourguide-iframeapi.min.js"></script>
+  <script defer src="https://widget.getyourguide.com/dist/js/getyourguide-iframeapi.min.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure GetYourGuide script loads with `defer`
- set minimum heights for activities iframe so all eight listings show on mobile

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6863309b6610832292ec6a5b6035133f