### PR TITLE
Fix mobile activities widget height

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -224,6 +224,7 @@
       .gyg-activities {
         /* allow the widget to size itself on mobile */
         height: auto;
-        min-height: 2000px;
+        /* ensure full activity list is visible on mobile */
+        min-height: 3200px;
       }
     }


### PR DESCRIPTION
## Summary
- adjust min-height so all 8 activities show on mobile

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686333df48d88322a5c304d86e8fa9e9