### PR TITLE
Remove frame from GetYourGuide widgets

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -77,15 +77,15 @@
       overflow: hidden;
       width: 100%;
     }
-    .gyg-frame {
-      width: 100%;
-      height: auto;
-      border: none;
-      border-radius: 12px;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-      display: block;
-      margin: 0 auto;
-    }
+      .gyg-frame {
+        width: 100%;
+        height: auto;
+        border: none;
+        border-radius: 0;
+        box-shadow: none;
+        display: block;
+        margin: 0 auto;
+      }
   .gyg-featured {
     height: 320px;
   }


### PR DESCRIPTION
## Summary
- remove `border-radius` and `box-shadow` from `.gyg-frame` to remove visible edges on GetYourGuide iframes

## Testing
- `tidy -errors index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863406b68c88322b1139ce1689a336b