### PR TITLE
Add privacy policy page and GA tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,14 @@
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500&family=Playfair+Display:wght@400;700&display=swap" rel="stylesheet">
   <link rel="icon" type="image/png" href="assets/images/favicon.png" />
   <link rel="stylesheet" href="assets/css/style.css" />
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-4PJDM2GGJ0"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-4PJDM2GGJ0');
+  </script>
 </head>
 <body>
   <main>
@@ -138,8 +146,9 @@
           <a href="https://x.com/intent/post?url=https://seine.travel&text=Discover+Paris+by+River!" aria-label="Share on X" target="_blank"><i class="fa-brands fa-x-twitter"></i></a>
         </div>
       </div>
-    </div>
-  </footer>
+      </div>
+      <p><a href="privacy.html">Privacy Policy</a></p>
+    </footer>
     </main>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.11.3/js/lightbox-plus-jquery.min.js"></script>
   <script defer src="https://widget.getyourguide.com/dist/js/getyourguide-iframeapi.min.js"></script>

--- a/pages/hotels.html
+++ b/pages/hotels.html
@@ -215,6 +215,14 @@
       }
     }
   </style>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-4PJDM2GGJ0"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-4PJDM2GGJ0');
+  </script>
 </head>
 <body>
   <main>
@@ -256,8 +264,9 @@
           <a href="https://x.com/intent/post?url=https://seine.travel&text=Discover+Paris+by+River!" aria-label="Share on X" target="_blank"><i class="fa-brands fa-x-twitter"></i></a>
         </div>
       </div>
-    </div>
-  </footer>
+      </div>
+      <p><a href="../privacy.html">Privacy Policy</a></p>
+    </footer>
   </main>
   <script>
     document.querySelector('.menu-toggle').addEventListener('click', function() {

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Privacy Policy | Seine Travel</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <main class="container" style="padding: 40px 20px;">
+    <h1>Privacy Policy</h1>
+    <p>At Seine.travel, we respect your privacy. This website uses Google Analytics 4 to collect anonymous data such as page views, clicks, device type, and country of origin. This data helps us understand how visitors use the site and improve your experience.</p>
+    <p>We do <strong>not</strong> collect personally identifiable information. No forms, names, emails, or payment details are collected or stored on this site.</p>
+    <p>By browsing Seine.travel, you agree to the use of basic cookies and anonymized tracking by Google Analytics.</p>
+    <p>If you have any questions, feel free to contact us at <a href="mailto:contact@seine.travel">contact@seine.travel</a>.</p>
+  </main>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -10,4 +10,7 @@
     <lastmod>2025-07-01</lastmod>
     <priority>0.8</priority>
   </url>
+  <url>
+    <loc>https://seine.travel/privacy.html</loc>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary
- add Google Analytics 4 snippet to `index.html` and `pages/hotels.html`
- link to privacy page from both footers
- create new `privacy.html` with policy text
- update sitemap with privacy page URL

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68672ef96e788322a6ac73b73f727eeb