### PR TITLE
Remove background from cruise CTA

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -301,7 +301,7 @@
 /* CTA above the GetYourGuide widget */
 .cta-container {
   text-align: center;
-  background-color: #f3f3f3;
+  background-color: transparent;
   padding: 24px 0;
   margin-bottom: 20px;
 }


### PR DESCRIPTION
## Summary
- remove background color from the top CTA container to keep the layout consistent

## Testing
- `npm test` *(fails: cannot find package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6868847d0e7c8322bf51ba3a8ed80747