### PR TITLE
Fix mobile CTA overlap

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -329,3 +329,10 @@
     padding: 12px 16px;
   }
 }
+
+/* Prevent floating CTA overlap on small screens */
+@media (max-width: 768px) {
+  body {
+    padding-bottom: 80px; /* space for fixed CTA button */
+  }
+}

--- a/index.html
+++ b/index.html
@@ -172,26 +172,24 @@
     });
   </script>
 
-  <!-- Floating CTA Button (Mobile only) -->
+  <!-- Floating CTA Button -->
   <style>
-    @media (max-width: 768px) {
-      .floating-cta {
-        position: fixed;
-        bottom: 20px;
-        right: 20px;
-        background-color: #01579b;
-        color: white;
-        padding: 14px 18px;
-        border-radius: 30px;
-        box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
-        font-weight: bold;
-        font-size: 16px;
-        text-decoration: none;
-        z-index: 9999;
-      }
-      .floating-cta:hover {
-        background-color: #003c71;
-      }
+    .floating-cta {
+      position: fixed;
+      bottom: 20px;
+      right: 20px;
+      background-color: #01579b;
+      color: white;
+      padding: 14px 18px;
+      border-radius: 30px;
+      box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+      font-weight: bold;
+      font-size: 16px;
+      text-decoration: none;
+      z-index: 9999;
+    }
+    .floating-cta:hover {
+      background-color: #003c71;
     }
   </style>
 


### PR DESCRIPTION
## Summary
- keep floating CTA styled for all screen sizes
- add mobile body padding so the CTA doesn't hide the footer

## Testing
- `none`

------
https://chatgpt.com/codex/tasks/task_e_6868889fb1608322a296cf5b78a63c33