### PR TITLE
Prevent CTA overlapping GetYourGuide attribution

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -298,6 +298,13 @@
   }
 }
 
+/* Ensure attribution text from widgets remains visible on desktop */
+@media (min-width: 769px) {
+  [data-gyg-widget="activities"] {
+    padding-bottom: 40px; /* room for "Powered by GetYourGuide" */
+  }
+}
+
 /* CTA above the GetYourGuide widget */
 .cta-container {
   text-align: center;


### PR DESCRIPTION
## Summary
- add desktop-only padding to the activities widget so the attribution from GetYourGuide stays visible

## Testing
- `git diff --check`
- `npx htmlhint index.html` *(fails: registry.npmjs.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686af049aab08322b6ece5f7f0d2376e