### PR TITLE
Fix CTA overlap on desktop

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -305,6 +305,13 @@
   }
 }
 
+/* Ensure CTA stays above the GetYourGuide attribution bar */
+@media (min-width: 769px) {
+  .gyg-cta {
+    margin-bottom: 60px;  /* adjust so the attribution isn't covered */
+  }
+}
+
 /* CTA above the GetYourGuide widget */
 .cta-container {
   text-align: center;


### PR DESCRIPTION
## Summary
- adjust CSS to add a margin for `.gyg-cta` on desktop widths

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686af3bb156c83229680016147792f42