### PR TITLE
Fix mobile whitespace for GetYourGuide widget

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -246,10 +246,10 @@
         display: block !important;
       }
       .gyg-activities {
-        /* allow the widget to size itself on mobile */
+        /* let the widget expand naturally on small screens */
         height: auto;
-        /* ensure full activity list is visible on mobile */
-        min-height: 3200px;
+        /* reduce enforced height to avoid large white space */
+        min-height: 1200px;
       }
 }
 


### PR DESCRIPTION
## Summary
- tweak CSS for `.gyg-activities` on small screens
- remove huge min-height and keep room for attribution

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686b23739d7c8322b5da171bbb34d0d5