### PR TITLE
Fix clipping on GetYourGuide widget

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -147,20 +147,22 @@
   width: 100%;
   display: block;
   overflow: visible;
-  padding-bottom: 80px; /* space for buttons/attribution */
   position: relative;
+  min-height: 650px;
+  padding-bottom: 90px; /* space for buttons/attribution */
 }
 [data-gyg-widget="availability"]::after {
   content: "";
   display: block;
-  height: 40px; /* additional breathing room */
+  height: 50px; /* additional breathing room */
 }
 @media (max-width: 480px) {
   [data-gyg-widget="availability"] {
-    padding-bottom: 100px; /* extra space on small screens */
+    min-height: 720px;
+    padding-bottom: 110px; /* extra space on small screens */
   }
   [data-gyg-widget="availability"]::after {
-    height: 50px;
+    height: 60px;
   }
 }
     .history-section {


### PR DESCRIPTION
## Summary
- adjust `[data-gyg-widget="availability"]` styling so the widget is never clipped

## Testing
- `npx stylelint assets/css/style.css` *(fails: npm error)*

------
https://chatgpt.com/codex/tasks/task_e_686b271345e48322991fb5ed8c563495