### PR TITLE
Fix spacing for GetYourGuide widget

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -134,8 +134,23 @@
       overflow-x: auto;
       overflow-y: visible;
       min-height: auto;
-      padding-bottom: 40px; /* space for attribution */
+      padding-bottom: 60px; /* space for Powered by GetYourGuide */
+      position: relative;
     }
+[data-gyg-widget="activities"]::after {
+  content: "";
+  display: block;
+  height: 32px; /* extra breathing room */
+}
+
+@media (max-width: 480px) {
+  [data-gyg-widget="activities"] {
+    padding-bottom: 80px;
+  }
+  [data-gyg-widget="activities"]::after {
+    height: 40px;
+  }
+}
 [data-gyg-widget="activities"] iframe {
   flex: 1 1 300px;
   display: block;


### PR DESCRIPTION
## Summary
- add extra bottom padding to GetYourGuide `activities` widget
- inject pseudo-element to guarantee "Powered by GetYourGuide" text isn't clipped
- ensure responsive padding on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b2e9f0fb48322be6396d168ef6428