### PR TITLE
Fix GYG widget clipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# seine-travel
+# Seine Travel
+
+This repository hosts the static site for Seine.travel.
+
+## GetYourGuide Widget
+
+The site integrates GetYourGuide's new widget using `data-gyg-widget="activities"`. The widget markup looks like:
+
+```html
+<div
+  data-gyg-widget="activities"
+  data-gyg-q="seine"
+  data-gyg-partner-id="X3LLOUG"
+  data-gyg-locale-code="en-US"
+  data-gyg-number-of-items="8">
+</div>
+```
+
+Styling for this container lives in `assets/css/style.css` and ensures the widget height adjusts on mobile and desktop so the attribution text stays visible.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -104,33 +104,20 @@
       overflow: hidden;
       width: 100%;
     }
-      .gyg-frame {
-        width: 100%;
-        height: auto;
-        border: none;
-        border-radius: 0;
-        box-shadow: none;
-        display: block;
-        margin: 0 auto;
-      }
     .activities-widget {
       background: linear-gradient(to bottom, #cceeff 0%, #f0f8ff 100%);
       padding: 40px 20px;
       text-align: center;
       width: 100%;
       overflow: visible;
-      min-height: auto;
     }
 [data-gyg-widget="activities"] {
-      width: 100%;
-      display: block;
-      flex-wrap: wrap;
-      justify-content: center;
-      overflow-x: visible;
-      overflow-y: visible;
-      margin-bottom: 80px; /* space for Powered by GetYourGuide */
-      min-height: 1000px;
-    }
+  width: 100%;
+  display: block;
+  overflow: visible;
+  min-height: 1200px;
+  padding-bottom: 80px; /* room for attribution */
+}
 [data-gyg-widget="activities"]::after {
   content: "";
   display: block;
@@ -234,14 +221,10 @@
         display: block;
         margin: 8px 0;
       }
-      .activities-widget .gyg-frame {
-        width: 100%;
-      }
       [data-gyg-widget="activities"] {
-        display: block;
         overflow: visible;
-        padding-bottom: 80px;
-        min-height: 2600px;
+        min-height: 2400px;
+        padding-bottom: 100px;
       }
       [data-gyg-widget="activities"]::after {
         height: 40px;

--- a/index.html
+++ b/index.html
@@ -51,7 +51,6 @@
   </div>
   <div class="container">
     <div
-      class="gyg-frame"
       data-gyg-widget="availability"
       data-gyg-tour-id="409183"
       data-gyg-partner-id="X3LLOUG"
@@ -70,8 +69,7 @@
         data-gyg-q="seine"
         data-gyg-partner-id="X3LLOUG"
         data-gyg-locale-code="en-US"
-        data-gyg-number-of-items="8"
-        class="gyg-frame">
+        data-gyg-number-of-items="8">
       </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- remove deprecated `.gyg-frame` styles
- style `[data-gyg-widget="activities"]` so the GetYourGuide widget height adjusts
- update mobile media query for widget height
- drop `gyg-frame` classes from HTML
- refresh README with GetYourGuide integration info

## Testing
- `npx htmlhint index.html` *(fails: prompts for install)*

------
https://chatgpt.com/codex/tasks/task_e_686b3b76cdac8322b964b43ee49efa4f